### PR TITLE
Revert "Fix new cpplint concern (#123)"

### DIFF
--- a/modules/pch/include/precomp.h
+++ b/modules/pch/include/precomp.h
@@ -5,6 +5,8 @@
 // Defines
 #define NOMINMAX
 
+// OpenMP
+#include <omp.h>
 // C++
 #include <iostream>
 #include <fstream>
@@ -24,8 +26,6 @@
 #include <stack>
 #include <queue>
 #include <sstream>
-// OpenMP
-#include <omp.h>
 // Graph common
 #include "modules/common/include/timer.h"
 #include "modules/common/include/randomize.h"


### PR DESCRIPTION
cpplint stopped to fail without this fix and started to fail with fix. That's why it needs to be reverted. Seems like it was some kind of bug on cpplint side that was fixed after some time.

This reverts commit 6cf00d42f540d3e003bef3155d6fe28570ff22ae.
